### PR TITLE
Quick IE Fix for Javascript File

### DIFF
--- a/media/js/connect.js
+++ b/media/js/connect.js
@@ -22,7 +22,7 @@ jQuery.noConflict();
 							maxWidth: 600,
 					        open: function(){closedialog = 1;$(document).bind('click', overlay_click_close);},
 					        focus: function(){closedialog = 0;},
-					        close: function(){$(document).unbind('click', overlay_click_close);},
+					        close: function(){$(document).unbind('click', overlay_click_close);}
 						});
     }
     


### PR DESCRIPTION
Edited line 25, removing last comma after last function. It was causing an exception error in IE browsers.
