### PR TITLE
Fixes issues that prevented activation of plugin when WordPress is not in the default directory.

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -1,5 +1,5 @@
 <?php
-require_once( dirname( dirname( dirname( dirname( __FILE__ )))) . '/wp-load.php' );
+require_once(ABSPATH . '/wp-load.php' );
 
 if( !defined( 'SOCIAL_CONNECT_PLUGIN_URL' )) {
   define( 'SOCIAL_CONNECT_PLUGIN_URL', plugins_url() . '/' . basename( dirname( __FILE__ )));

--- a/diagnostics/test.php
+++ b/diagnostics/test.php
@@ -1,5 +1,5 @@
 <?php
-require_once( dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/wp-load.php' );
+require_once(ABSPATH . '/wp-load.php' );
 
 $testing = "";
 $msg = "";

--- a/twitter/callback.php
+++ b/twitter/callback.php
@@ -1,5 +1,5 @@
 <?php
-require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/wp-load.php');
+require_once(ABSPATH . '/wp-load.php');
 require_once(dirname(__FILE__) . '/EpiCurl.php' );
 require_once(dirname(__FILE__) . '/EpiOAuth.php' );
 require_once(dirname(__FILE__) . '/EpiTwitter.php' );

--- a/twitter/connect.php
+++ b/twitter/connect.php
@@ -1,5 +1,5 @@
 <?php
-require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/wp-load.php');
+require_once(ABSPATH . '/wp-load.php');
 require_once(dirname(__FILE__) . '/EpiCurl.php' );
 require_once(dirname(__FILE__) . '/EpiOAuth.php' );
 require_once(dirname(__FILE__) . '/EpiTwitter.php' );

--- a/utils.php
+++ b/utils.php
@@ -1,5 +1,5 @@
 <?php
-require_once( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/wp-load.php' );
+require_once(ABSPATH . '/wp-load.php' );
 
 function social_connect_get_user_by_meta( $meta_key, $meta_value ) {
 	global $wpdb;


### PR DESCRIPTION
Uses ABSPATH to ensure that the scripts can find the wp-load.php file
in WordPress installations that keep WordPress in a different folder.
