### PR TITLE
Fix avatar rendering

### DIFF
--- a/social-connect.php
+++ b/social-connect.php
@@ -226,8 +226,9 @@ function sc_filter_avatar($avatar, $id_or_email, $size, $default, $alt) {
 	$custom_avatar = '';
 	$social_id = '';
 	$provider_id = '';
+	$user_id = (!is_integer($id_or_email) && !is_string($id_or_email) && get_class($id_or_email)) ? $id_or_email->user_id : $id_or_email;
 	
-	if(is_string($id_or_email) || is_int($id_or_email) || (get_class($id_or_email) && !empty($id_or_email->user_id)))
+	if(!empty($user_id))
 	{
 		// Providers to search for (assume user prefers their current logged in service)
 		// Note: OpenID providers use gravatars
@@ -238,7 +239,7 @@ function sc_filter_avatar($avatar, $id_or_email, $size, $default, $alt) {
 			$providers = array('twitter', 'facebook');
 		
 		foreach($providers as $search_provider) {
-			$social_id = get_user_meta($id_or_email, 'social_connect_'.$search_provider.'_id', true);
+			$social_id = get_user_meta($user_id, 'social_connect_'.$search_provider.'_id', true);
 			if(!empty($social_id)) {
 				$provider_id = $search_provider;
 				break;


### PR DESCRIPTION
If $id_or_email contained an object, get_user_meta was not resolving it correctly which could cause the wrong avatar to render. Now we extract the ID from the object in advance.
