### PR TITLE
Using secure connection of Google cdn

### DIFF
--- a/media.php
+++ b/media.php
@@ -3,7 +3,7 @@
 function sc_add_stylesheets(){
 	if( !wp_style_is( 'social_connect', 'registered' ) ) {
 		wp_register_style( "social_connect", SOCIAL_CONNECT_PLUGIN_URL . "/media/css/style.css" );
-		wp_register_style( "jquery-ui", 'http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.5/themes/smoothness/jquery-ui.css' );
+		wp_register_style( "jquery-ui", 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.5/themes/smoothness/jquery-ui.css' );
 	}
 
 	if ( did_action( 'wp_print_styles' ) ) {


### PR DESCRIPTION
As jqueryui does not load on secure website using this plugin, using secure link fixes it, works on both secure as well as non secure websites.
