### PR TITLE
Better WP Security plugin Fix/Limitation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,11 @@ Special thanks to:
 
 And everyone else in the forums sharing the fixes they find and answering each others questions.
 
+= Notes =
+
+* Better WP Security plugin Fix/Limitation
+  Disable “Prevent long URL strings” option
+
 = Contribute =
 
 Social Connect is rapidly growing in popularity and help with the growing pains is appreciated. 


### PR DESCRIPTION
Facebook login gets stuck after authorization from user due to enable of  “Prevent long URL strings” option. To use this user must turn off this feature.
