### PR TITLE
Increased the cURL timeout to 200 for facebook request.

### DIFF
--- a/facebook/facebook.php
+++ b/facebook/facebook.php
@@ -111,7 +111,7 @@ class Facebook
   public static $CURL_OPTS = array(
     CURLOPT_CONNECTTIMEOUT => 10,
     CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_TIMEOUT        => 60,
+    CURLOPT_TIMEOUT        => 200,
     CURLOPT_USERAGENT      => 'facebook-php-2.0',
   );
 


### PR DESCRIPTION
I was getting "Operation timed out after 5117 milliseconds with 0 out of -1 bytes received social connect" for facebook connect, so I have increased the cURL timeout. 
