### PR TITLE
Fix PHP notice in social-connect.php

### DIFF
--- a/social-connect.php
+++ b/social-connect.php
@@ -294,8 +294,9 @@ function sc_filter_avatar($avatar, $id_or_email, $size, $default, $alt) {
 	$custom_avatar = '';
 	$social_id = '';
 	$provider_id = '';
-	$user_id = (!is_integer($id_or_email) && !is_string($id_or_email) && get_class($id_or_email)) ? $id_or_email->user_id : $id_or_email;
-	
+	$class = is_object( $id_or_email )? get_class( $id_or_email ) : false;
+	$user_id = ( ! is_integer( $id_or_email ) && ! is_string( $id_or_email ) && $class )? $id_or_email->user_id : $id_or_email;
+
 	if (!empty($user_id)) {
 		// Providers to search for (assume user prefers their current logged in service)
 		// Note: OpenID providers use gravatars


### PR DESCRIPTION
Prevent PHP Notice from the `get_class()` method when `$id_or_email` is `false` or `null`.
