### PR TITLE
Change Google+ callback to always use the provided access token.

### DIFF
--- a/google-plus/callback.php
+++ b/google-plus/callback.php
@@ -21,12 +21,8 @@ if (isset($_GET['code'])) {
 		unset( $_SESSION['access_token'] );
 	}
 
-	if ( isset( $_SESSION['access_token'] ) && $_SESSION['access_token'] ) {
-		$client->setAccessToken( $_SESSION['access_token'] );
-	} elseif ( isset( $code ) ) {
-		$client->authenticate( $_GET['code'] );
-		$_SESSION['access_token'] = $client->getAccessToken();
-	}
+	$client->authenticate( $_GET['code'] );
+	$_SESSION['access_token'] = $client->getAccessToken();
 
 	$token = json_decode( $client->getAccessToken() );
 


### PR DESCRIPTION
I think this fixes #73, but I'm not well-versed in OAuth.