### PR TITLE
Allow for custom user_login values via social_connect_user_login filter

### DIFF
--- a/social-connect.php
+++ b/social-connect.php
@@ -206,6 +206,8 @@ function sc_social_connect_process_login( $is_ajax = false ) {
 			break;
 	}
 
+	$user_login = apply_filters( 'social_connect_user_login', $user_login, $sc_email, $sc_first_name, $sc_last_name, $social_connect_provider );
+
 	// Cookies used to display welcome message if already signed in recently using some provider
 	setcookie("social_connect_current_provider", $social_connect_provider, time()+3600, SITECOOKIEPATH, COOKIE_DOMAIN, false, true );
 


### PR DESCRIPTION
Fixes #41

The open issue #41 suggested making this an option in the settings, but this could lead to confusion. (An option might mislead site admins that they are making email addresses the user_login everyone on the site, when this would only affect new registrations via SSO.)

Instead, I have introduced a filter that gives developers (who will know better, *right?*) the ability to modify the `user_login` value before the new user is inserted. In the case of creating an email login, they can just add this to the `functions.php`:
```
add_filter('social_connect_user_login', function( $user_login, $sc_email, $sc_first_name, $sc_last_name, $social_connect_provider ){
	return $sc_email;
},10,5);
```
Quick, painless, and solves the problem at hand. :)